### PR TITLE
Adding-argo-app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 .terraformrc
 
 terraform.rc
+terraform.tfstate
+terraform.tfstate.backup
+.terraform.lock.hcl

--- a/tf_resources/applications/.terraform.lock.hcl
+++ b/tf_resources/applications/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.14.0"
+  constraints = ">= 1.7.0"
+  hashes = [
+    "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+  ]
+}

--- a/tf_resources/applications/go-app-argocd.yml
+++ b/tf_resources/applications/go-app-argocd.yml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: 'go-app'
+  namespace: argocd
+#  annotations:
+#    notifications.argoproj.io/subscribe.on-deployed.slack: k8s-deployment-status
+#    notifications.argoproj.io/subscribe.on-sync-failed.slack: k8s-deployment-status
+#    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: k8s-deployment-status
+spec:
+  destination:
+    name: 'in-cluster'
+    namespace: 'goapp-service'
+  source:
+    path: 'goapp-service'
+    repoURL: 'https://github.com/vishal267/thefinisher-app-manifests/'
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+      - values.yaml
+  project: 'default'
+  syncPolicy:
+    automated:
+      prune: true  # Optional: Automatically prune resources that are no longer tracked
+      selfHeal: true  # Optional: Automatically sync resources
+    syncOptions:
+      - CreateNamespace=true  # Ensure this is correctly nested

--- a/tf_resources/applications/goapp.tf
+++ b/tf_resources/applications/goapp.tf
@@ -1,0 +1,31 @@
+resource "kubectl_manifest" "test" {
+  yaml_body = <<YAML
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: 'go-app'
+  namespace: argo-cd
+#  annotations:
+#    notifications.argoproj.io/subscribe.on-deployed.slack: k8s-deployment-status
+#    notifications.argoproj.io/subscribe.on-sync-failed.slack: k8s-deployment-status
+#    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: k8s-deployment-status
+spec:
+  destination:
+    name: 'in-cluster'
+    namespace: 'goapp-service'
+  source:
+    path: 'goapp-service'
+    repoURL: 'https://github.com/vishal267/thefinisher-app-manifests/'
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+      - values.yaml
+  project: 'default'
+  syncPolicy:
+    automated:
+      prune: true  # Optional: Automatically prune resources that are no longer tracked
+      selfHeal: true  # Optional: Automatically sync resources
+    syncOptions:
+      - CreateNamespace=true  # Ensure this is correctly nested
+YAML
+}

--- a/tf_resources/applications/providers.tf
+++ b/tf_resources/applications/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
+  }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Argo CD application configuration for `go-app`, enabling automated deployments and self-healing capabilities.
	- Added a new Kubernetes application resource for `go-app`, facilitating easier management of application manifests.
	- Updated Terraform configuration to include a new provider for Kubernetes, improving resource management.

- **Chores**
	- Updated `.gitignore` to exclude sensitive Terraform state files and lock files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->